### PR TITLE
application file was missing application depedencies

### DIFF
--- a/src/ewpcap.app.src
+++ b/src/ewpcap.app.src
@@ -1,3 +1,6 @@
 {application, ewpcap,
     [{description, "PCAP NIF interface"},
-    {vsn, "0.2.3"}]}.
+    {vsn, "0.2.3"},
+    {applications, [kernel, stdlib]}
+]}.
+


### PR DESCRIPTION
Hi Michael,

In order for exrm to correctly build all dependencies we needed to add application dependencies to the ewpcap application file.

Thanks from the team
Chris