### PR TITLE
Make ewpcap runnable on Windows 10.

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -4,50 +4,62 @@ This document describes what tools are needed and how they should be set up to b
 
 ### Tools
 
-* **MS Visual Studio C++ Express** has to be installed. The IDE will not be used, just the MS Visual Studio compiler (`cl.exe`). Version used: 10.0
+* **MS Visual Studio C++ Express** has to be installed. The IDE will not be used, just the MS Visual Studio compiler (`cl.exe`). Version used: 14.0 (cl.exe version 19.00.x for x86)
 
-* **MS Windows SDK** provides some headers and libraries. Version used: 7.1
+* **MS Windows SDK** provides some headers and libraries. Versions used: v7.1A, v10.0A (on Win10, both versions were actually required, possibly installed at once). 
 
-* **Cygwin** is needed to get an usable console on Windows. The developer tools such as make and git should be included in the installation (it needs to be selected during the installation as it is not by default).
 
-* **Erlang/OTP**'s binary package for Windows is available. Version used: R15B01
+* **Cygwin** is needed to get an usable console on Windows. The developer tools such as make and git should be included in the installation (it needs to be selected during the installation as it is not by default). Alternatively, installing `git` for Windows with the optional `git-bash` can provide a minimal environment with the proper compatibility required to compile this library.
+
+* **Erlang/OTP**'s 32-bit binary package for Windows is available. Version used: Erlang/OTP-20
 
 * **Git** is used for cloning rebar and ewpcap from Github.
 
-* **Rebar** is used for compilation of ewpcap. It should not be installed at this stage!
+* **Rebar3** is used for compilation of ewpcap. It should not be installed at this stage!
 
 * **WinPcap** is a dependency of ewpcap. It is a library for capturing network traffic (libpcap in Linux/UNIX). There are two types of the WinPcap for Windows:
-	* driver + DLLs is the default installation of the library
-	* development version - is a directory containing source files of the WinPcap library. It can be installed into `C:/WpdPack`
+	* driver + DLLs is the default installation of the library. Usually installed in `C:/Program Files (x86)/WinPcap/`
+	* development version - is a directory containing source files of the WinPcap library. It can be installed into `C:/WpdPack`, or the development headers could be added to the actual install.
 
-* **Pkt** is optional. TODO
+* **Pkt** is optional, but useful to decode actual packets returned by a packet capture.
 
 ### Installation and configuration
 
-After all the tools are installed (apart from rebar), the `PATH`, `INCLUDE` and `LIB` variables in Cygwin must be set. The configuration of these variables may look like this (appended to the `C:/cygwin/home/user/.bashrc`):
+After all the tools are installed (apart from rebar), the `PATH`, `INCLUDE` and `LIB` variables in Cygwin must be set. The configuration of these variables may look like this (appended to the `C:/cygwin/home/user/.bashrc`, or just `C:/Users/<user>/.bashrc` if using git-bash):
 
-``` shell
-export VSINSTALLDIR='C:\Program Files\Microsoft Visual Studio 10.0\'
-export WindowsSdkDir='C:\Program Files\Microsoft SDKs\Windows\v7.1\'
-export ERLANGDIR='C:\Program Files\erl5.9.1\'
-export WINPCAPDIR='C:\WpdPack\'
-
+```shell
+export VSINSTALLDIR='C:\Program Files (x86)\Microsoft Visual Studio 14.0\'      # path to Visual studio
+export WindowsSdkDir='C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\'    # path to v10.0A SDK for headers
+export WindowsSdkDirOld='C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\'  # path to V7.1A SDK for headers
+export WindowsKitDir='C:\Program Files (x86)\Windows Kits\10\'                  # path to Windows kit for further headers and libs
+export WindowsKitDirIncl="${WindowsKitDir}"'Include\10.0.14393.0\'              # newest version for includes in kits
+export WindowsKitLibUm="${WindowsKitDir}"'Lib\10.0.14393.0\um\x86'              # windows kit libraries
+export WindowsKitLibUcrt="${WindowsKitDir}"'Lib\10.0.14393.0\ucrt\x86'          # windows kit libraries
+export ERLANGDIR='C:\Program Files (x86)\erl-9.0\'                              # path to Erlang install
+export WINPCAPDIR='C:\WpdPack\'                                                 # path to WinPcap
+export ERTSVSN='erts-9.0'                                                       # Version of the Erlang runtime system (to find C headers)
 
 export VCINSTALLDIR="$VSINSTALLDIR"'VC\'
 export DevEnvDir="$VSINSTALLDIR"'Common7\IDE\'
 
-export INCLUDE="${VCINSTALLDIR}include;${WindowsSdkDir}Include;${WindowsSdkDir}Include\\gl"
-export INCLUDE="${INCLUDE};${WINPCAPDIR}Include;${ERLANGDIR}erts-5.9.1\\include;${ERLANGDIR}usr\\include"
-export LIB="${VCINSTALLDIR}lib;${WindowsSdkDir}Lib;${WINPCAPDIR}Lib;${ERLANGDIR}erts-5.9.1\\lib"
-export LIBPATH="${LIBPATH}${VCINSTALLDIR}lib;"
+export INCLUDE="${VCINSTALLDIR}include;${WindowsSdkDir}Include;${WindowsSdkDir}Include\\gl;${WindowsSdkDirOld}Include;${WindowsSdkDirOld}Include\\gl"
+export INCLUDE="${INCLUDE};${WindowsKitDir}Include;${WindowsKitDirIncl};${WindowsKitDirIncl}\\shared;${WindowsKitDirIncl}\\ucrt;${WindowsKitDirIncl}\\um"
+export INCLUDE="${INCLUDE};${WINPCAPDIR}Include;${ERLANGDIR}{$ERTSVSN}\\include;${ERLANGDIR}usr\\include"
+export LIB="${VCINSTALLDIR}lib;${WindowsSdkDir}Lib;${WINPCAPDIR}Lib;${ERLANGDIR}{$ERTSVSN}\\lib"
+export LIBPATH="${LIBPATH}${VCINSTALLDIR}lib;${WindowsKitLib}"
 
+#convert paths
 c_VSINSTALLDIR=`cygpath -ua "$VSINSTALLDIR\\\\"`
 c_WindowsSdkDir=`cygpath -ua "$WindowsSdkDir\\\\"`
+c_WindowsSdkDirOld=`cygpath -ua "$WindowsSdkDirOld\\\\"`
+c_WindowsKitDir=`cygpath -ua "$WindowsKitDir\\\\"`
 c_ERLANGDIR=`cygpath -ua "$ERLANGDIR\\\\"`
 c_WINPCAPDIR=`cygpath -ua "$WINPCAPDIR\\\\"`
 
+export PATH="${c_WindowsKitir}Bin:$PATH"
 export PATH="${c_WindowsSdkDir}Bin:$PATH"
-export PATH="${c_WindowsSdkDir}Bin/NETFX 4.0 Tools:$PATH"
+export PATH="${c_WindowsSdkDirOld}Bin:$PATH"
+export PATH="${c_WindowsSdkDir}Bin/NETFX 4.6.2 Tools:$PATH"
 export PATH="${c_VSINSTALLDIR}VC/vcpackages:$PATH"
 export PATH="${c_VSINSTALLDIR}Common7/Tools:$PATH"
 export PATH="${c_VSINSTALLDIR}VC/Bin:$PATH"
@@ -59,12 +71,16 @@ Rebar can be downloaded using git and built with `./bootstrap` command. (`make` 
 
 ### Building ewpcap
 
-In order to build ewpcap, download it from Github and copy rebar (that was built in the previous step) to ewpcap's directory. The first line of the Makefile has to look like this:
+ewpcap can be compiled by calling `rebar3 compile`.
+
+For an environment using makefiles, download ewpcap from Github and copy rebar3 (that was built in the previous step) to ewpcap's directory. The first line of the Makefile has to look like this:
+
 ```
-REBAR=./rebar
+REBAR=./rebar3 compile
 ```
 
 It should be possible to build the project with the `make` command now.
+
 
 ### Using ewpcap
 

--- a/c_src/ewpcap.c
+++ b/c_src/ewpcap.c
@@ -604,11 +604,7 @@ nif_pcap_stats(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
                 enif_make_uint(env, ps.ps_recv),
                 enif_make_uint(env, ps.ps_drop),
                 enif_make_uint(env, ps.ps_ifdrop),
-#ifdef WIN32
-                enif_make_uint(env, ps.bs_capt)
-#else
                 enif_make_uint(env, 0)
-#endif
                 ));
 }
 

--- a/c_src/ewpcap.c
+++ b/c_src/ewpcap.c
@@ -48,6 +48,7 @@
 # include <sys/socket.h>
 # include <netinet/in.h>
 # include <arpa/inet.h>
+# define RFMON_SUPPORTED
 #endif
 
 #include "erl_nif.h"
@@ -291,9 +292,11 @@ nif_pcap_open_live(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     if (buffer_size > 0)
         (void)pcap_set_buffer_size(ep->p, buffer_size);
 
+#if defined(RFMON_SUPPORTED)
     /* Set monitor mode */
     if (pcap_can_set_rfmon(ep->p) == 1)
         (void)pcap_set_rfmon(ep->p, rfmon);
+#endif
 
     /* Return failure on error and warnings */
     if (pcap_activate(ep->p) != 0) {

--- a/c_src/ewpcap.c
+++ b/c_src/ewpcap.c
@@ -129,7 +129,7 @@ ewpcap_loop(void *arg)
 
     ep->env = enif_alloc_env();
     if (ep->env == NULL)
-        goto ERROR;
+        goto ERROR_LABEL;
 
     rv = pcap_loop(ep->p, -1 /* loop forever */, ewpcap_send, (u_char *)ep);
 
@@ -146,7 +146,7 @@ ewpcap_loop(void *arg)
             break;
     }
 
-ERROR:
+ERROR_LABEL:
     /* env is freed in resource cleanup */
     return NULL;
 }
@@ -374,7 +374,7 @@ nif_pcap_lookupdev(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
             struct sockaddr_in *sin = (struct sockaddr_in *)saddr; \
  \
             if (!enif_alloc_binary(sizeof(sin->sin_addr.s_addr), &buf)) \
-                goto ERROR; \
+                goto ERROR_LABEL; \
  \
             (void)memcpy(buf.data, &(sin->sin_addr.s_addr), buf.size); \
         } \
@@ -383,7 +383,7 @@ nif_pcap_lookupdev(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
             struct sockaddr_in6 *sin = (struct sockaddr_in6 *)saddr; \
  \
             if (!enif_alloc_binary(sizeof(sin->sin6_addr), &buf)) \
-                goto ERROR; \
+                goto ERROR_LABEL; \
  \
             (void)memcpy(buf.data, &(sin->sin6_addr), buf.size); \
         } \
@@ -491,7 +491,7 @@ nif_pcap_findalldevs(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
             atom_ok,
             dev);
 
-ERROR:
+ERROR_LABEL:
     pcap_freealldevs(alldevsp);
 
     /* MAKE_ADDR macro */

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
     {"win32", "CXX", "cl.exe"},
     {"win32", "LINKER", "link.exe"},
     {"win32", "DRV_CFLAGS", "/W4 /wd4100 /wd4127 /D__WIN32__ /DWIN32"},
-    {"win32", "DRV_LDFLAGS", "$DRV_LDFLAGS ws2_32.lib wpcap.lib Packet.lib"}
+    {"win32", "DRV_LDFLAGS", "$DRV_LDFLAGS /LIBPATH:\"$WindowsKitLibUm\" /LIBPATH:\"$WindowsKitLibUcrt\" ws2_32.lib wpcap.lib Packet.lib"}
     ]}.
 
 {port_specs, [


### PR DESCRIPTION
This PR includes the following changes:

- adapting the code to the newest WinPcap libraries and bindings
- change a few compiler details to work well with cl.exe without (hopefully) loss of compatibility on other systems
- updating build instructions and commands to work with newer SDKs and Windows environments

A gotcha is that the compile line used for the port compiler now relies on the environment to be able to work, since I'm not aware of otherwise good ways to have LIBPATH updated without passing the paths and options directly to the compiler. This could possibly be moved to a rebar.config.script part of the file that handles it dynamically.