### PR TITLE
Add Darwin to pc specs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,8 +8,8 @@
 ]}.
 
 {port_env, [
-    {"linux|bsd", "LDFLAGS", "-lpcap $LDFLAGS -Wl,-z,relro,-z,now -Wl,-z,noexecstack"},
-    {"linux|bsd", "CFLAGS",
+    {"linux|bsd|Darwin", "LDFLAGS", "-lpcap $LDFLAGS -Wl,-z,relro,-z,now -Wl,-z,noexecstack"},
+    {"linux|bsd|Darwin", "CFLAGS",
         "$CFLAGS $EWPCAP_CFLAGS -Wall -pedantic -fwrapv -D_FORTIFY_SOURCE=2 -O3 -fstack-protector-strong -Wformat -Werror=format-security -fno-strict-aliasing -Wconversion -Wshadow -Wpointer-arith -Wcast-qual"},
     {"solaris", "LDFLAGS", "-lpcap $LDFLAGS"},
     {"solaris", "CFLAGS", "-std=c99 -D_POSIX_C_SOURCE=200112L -D__EXTENSIONS__=1 $CFLAGS"},
@@ -23,7 +23,7 @@
 ]}.
 
 {port_specs, [
-    {"linux|bsd", "priv/ewpcap.so", ["c_src/ewpcap.c"]},
+    {"linux|bsd|darwin", "priv/ewpcap.so", ["c_src/ewpcap.c"]},
     {"solaris", "priv/ewpcap.so", ["c_src/ewpcap.c"]},
     {"win32", "priv/ewpcap.dll", ["c_src/ewpcap.c"]}
 ]}.


### PR DESCRIPTION
This commit adds Darwin (mac os) to pc specs. 

Example showing it works, sniffing an http request to example.com  : 

```erlang
sudo rebar3 shell 

===> Verifying dependencies...
===> Analyzing applications...
===> Compiling ewpcap
Erlang/OTP 25 [DEVELOPMENT] [erts-12.0] [source-6dbab60b39] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V12.0  (abort with ^G)
1> {ok, Socket} = ewpcap:open("en0", [{filter, "tcp and port 80"}]).
{ok,{ewpcap_resource,#Ref<0.3454668280.626262017.220796>,
                     #Ref<0.3454668280.626393089.220795>}}
2> {ok, Packet0} = ewpcap:read(Socket).
{ok,<<96,95,141,60,31,242,160,120,23,163,253,116,8,0,69,
      0,0,64,0,0,64,0,64,6,60,216,192,...>>}
3> {ok, Packet1} = ewpcap:read(Socket).
{ok,<<160,120,23,163,253,116,96,95,141,60,31,242,8,0,69,
      0,0,60,216,1,0,0,55,6,173,218,93,...>>}
4> {ok, Packet2} = ewpcap:read(Socket).
{ok,<<96,95,141,60,31,242,160,120,23,163,253,116,8,0,69,
      0,0,52,0,0,64,0,64,6,60,228,192,...>>}
5> {ok, Packet3} = ewpcap:read(Socket).
{ok,<<96,95,141,60,31,242,160,120,23,163,253,116,8,0,69,
      0,0,127,0,0,64,0,64,6,60,153,192,...>>}
6> {ok, Packet4} = ewpcap:read(Socket).
{ok,<<160,120,23,163,253,116,96,95,141,60,31,242,8,0,69,
      0,0,52,216,3,0,0,55,6,173,224,93,...>>}
7> {ok, Packet5} = ewpcap:read(Socket).
{ok,<<160,120,23,163,253,116,96,95,141,60,31,242,8,0,69,
      0,5,220,216,4,0,0,55,6,168,55,93,...>>}
8> {ok, Packet6} = ewpcap:read(Socket).
{ok,<<160,120,23,163,253,116,96,95,141,60,31,242,8,0,69,
      0,0,211,216,5,0,0,55,6,173,63,93,...>>}
9> [_, _,_, Payload] = pkt:decapsulate(Packet6).
[{ether,<<160,120,23,163,253,116>>,
        <<96,95,141,60,31,242>>,
        2048,0},
 {ipv4,4,5,0,211,55301,0,0,0,55,6,44351,
       {93,184,216,34},
       {192,168,7,93},
       <<>>},
 {tcp,80,63019,3829940443,3630663574,8,0,0,0,0,1,1,0,0,0,128,
      18670,0,
      <<1,1,8,10,227,205,241,...>>},
 <<"hout prior coordination or asking for permission.</p>\n    <p><a href=\"https://www.iana.org/domains/e"...>>]
```

Edit:

Should have added : 

```shell
$ uname -a 
Darwin MacBook 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:06:51 PST 2021; root:xnu-7195.81.3~1/RELEASE_ARM64_T8101 arm64
```