### PR TITLE
Add stdint.h for INT32_MAX

### DIFF
--- a/c_src/ewpcap.c
+++ b/c_src/ewpcap.c
@@ -31,6 +31,8 @@
 #include <errno.h>
 #include <pcap.h>
 #include <string.h>
+#include <stdint.h>
+
 
 #if defined(__SVR4) && defined(__sun)
 #define u_int8_t uint8_t


### PR DESCRIPTION
I found that debian buster and ubuntu wants `stdint.h` pulled in otherwise  `error: ‘INT32_MAX’ undeclared (first use in this function)`  ensues. I think this should be fine on all platforms, but unsure about windows. 